### PR TITLE
Specify bundle for localized strings

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayerError.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayerError.swift
@@ -14,9 +14,9 @@ public enum VelociPlayerError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .unableToBuffer:
-            return NSLocalizedString("UNABLE_TO_BUFFER_ERROR_DESCRIPTION", comment: "An error that occurs when the player is unable to buffer the current item.")
+            return NSLocalizedString("UNABLE_TO_BUFFER_ERROR_DESCRIPTION", bundle: .module, comment: "An error that occurs when the player is unable to buffer the current item.")
         case .invalidSRT:
-            return NSLocalizedString("INVALID_SRT_ERROR_DESCRIPTION", comment: "An error that occurs when the player is unable to decode an SRT file.")
+            return NSLocalizedString("INVALID_SRT_ERROR_DESCRIPTION", bundle: .module, comment: "An error that occurs when the player is unable to decode an SRT file.")
         }
     }
 }


### PR DESCRIPTION
This PR resolves an issue where localized errors would return just the keys, as the bundle was not specified