### PR TITLE
Removed subcription to AVPlayerDidPlayToEndTime

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -63,13 +63,6 @@ extension VelociPlayer {
                 self?.onPlayerTimeControlled()
             }
             .store(in: &subscribers)
-        
-        NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime, object: nil)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.progress = 1
-            }
-            .store(in: &subscribers)
     }
     
     internal func prepareNewPlayerItem() {


### PR DESCRIPTION
This notification seems to fire at unexpected times, causing unexpected behavior in apps.