### PR TITLE
[Feature] Add support for replacing the current AVPlayerItem

### DIFF
--- a/Sources/VelociPlayer/Resources/en.lproj/Localizable.strings
+++ b/Sources/VelociPlayer/Resources/en.lproj/Localizable.strings
@@ -6,5 +6,5 @@
   
 */
 
-"INVALID_SRT_ERROR_DESCRIPTION" = "Unable to parse the SRT string/file provided to VelociPlayer"
-"UNABLE_TO_BUFFER_ERROR_DESCRIPTION" = "An error occurred while buffering the current item"
+"INVALID_SRT_ERROR_DESCRIPTION" = "Unable to parse the SRT string/file provided to VelociPlayer";
+"UNABLE_TO_BUFFER_ERROR_DESCRIPTION" = "An error occurred while buffering the current item";

--- a/Sources/VelociPlayer/Source/VelociPlayer+Seeking.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Seeking.swift
@@ -44,7 +44,7 @@ extension VelociPlayer {
     @discardableResult
     override public func seek(to time: VPTime) async -> Bool {
         let completed = await super.seek(to: time)
-        await updateNowPlayingForSeeking()
+        updateNowPlayingForSeeking()
         return completed
     }
     
@@ -73,7 +73,7 @@ extension VelociPlayer {
             toleranceBefore: toleranceBefore,
             toleranceAfter: toleranceAfter
         )
-        await updateNowPlayingForSeeking()
+        updateNowPlayingForSeeking()
         return completed
     }
     
@@ -86,7 +86,7 @@ extension VelociPlayer {
     @discardableResult
     override public func seek(to date: Date) async -> Bool {
         let completed = await super.seek(to: date)
-        await updateNowPlayingForSeeking()
+        updateNowPlayingForSeeking()
         return completed
     }
 }

--- a/Sources/VelociPlayer/Source/VelociPlayer.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer.swift
@@ -93,7 +93,7 @@ public class VelociPlayer: AVPlayer, ObservableObject {
     /// The source URL of the media file
     public var mediaURL: URL? {
         didSet {
-            prepareNewPlayerItem()
+            mediaURLChanged()
         }
     }
     
@@ -129,13 +129,22 @@ public class VelociPlayer: AVPlayer, ObservableObject {
         self.autoPlay = autoPlay
         self.mediaURL = mediaURL
         self.startTime = startTime
+        
         self.publisher(for: \.status)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.statusChanged()
             }
             .store(in: &subscribers)
-        prepareNewPlayerItem()
+        
+        self.publisher(for: \.currentItem)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.prepareNewPlayerItem()
+            }
+            .store(in: &subscribers)
+        
+        mediaURLChanged()
     }
     
     internal func prepareForPlayback() {


### PR DESCRIPTION
VelociPlayer now properly handles using `replaceCurrentItem` if you'd like more manual control of player items.
This also includes a fix to the localizable file that caused error messages to not show up.