### PR TITLE
[Bug] Properties for previous player items are still subscribed to.

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -82,6 +82,7 @@ extension VelociPlayer {
         self.mediaURL = (currentItem.asset as? AVURLAsset)?.url
         currentItem.preferredForwardBufferDuration = 10
         
+        self.currentItemSubscribers = []
         currentItem.publisher(for: \.isPlaybackBufferEmpty)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isPlaybackBufferEmpty in
@@ -89,7 +90,7 @@ extension VelociPlayer {
                     self?.bufferStatusChanged(to: .empty)
                 }
             }
-            .store(in: &subscribers)
+            .store(in: &currentItemSubscribers)
         
         currentItem.publisher(for: \.isPlaybackLikelyToKeepUp)
             .receive(on: DispatchQueue.main)
@@ -98,7 +99,7 @@ extension VelociPlayer {
                     self?.bufferStatusChanged(to: .likelyToKeepUp)
                 }
             }
-            .store(in: &subscribers)
+            .store(in: &currentItemSubscribers)
         
         currentItem.publisher(for: \.isPlaybackBufferFull)
             .receive(on: DispatchQueue.main)
@@ -107,14 +108,14 @@ extension VelociPlayer {
                     self?.bufferStatusChanged(to: .full)
                 }
             }
-            .store(in: &subscribers)
+            .store(in: &currentItemSubscribers)
         
         currentItem.publisher(for: \.loadedTimeRanges)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] timeRanges in
                 self?.updateBufferTime(timeRanges: timeRanges)
             }
-            .store(in: &subscribers)
+            .store(in: &currentItemSubscribers)
         
         currentItem.publisher(for: \.status)
             .receive(on: DispatchQueue.main)
@@ -126,7 +127,7 @@ extension VelociPlayer {
                     break
                 }
             }
-            .store(in: &subscribers)
+            .store(in: &currentItemSubscribers)
         
         Task.detached {
             await self.updateCurrentItemDuration()

--- a/Sources/VelociPlayer/Source/VelociPlayer.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer.swift
@@ -110,6 +110,7 @@ public class VelociPlayer: AVPlayer, ObservableObject {
     
     internal var timeObserver: Any?
     internal var subscribers = [AnyCancellable]()
+    internal var currentItemSubscribers = [AnyCancellable]()
     internal var commandTargets = [MPRemoteCommand: Any]()
     
     internal var nowPlayingInfo: [String: Any]? {


### PR DESCRIPTION
This pull request fixes an issue that caused properties previous items to still be subscribed to. It has been fixed by storing subscribers for the current item in a separate array that can be wiped when needed.