### PR TITLE
[Bug] Improve Current Item Subscribers' Lifecycle

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
@@ -51,6 +51,7 @@ extension VelociPlayer {
         }
         
         subscribers.removeAll()
+        currentItemSubscribers.removeAll()
         
         self.displayInSystemPlayer = false
         self.pause()

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -76,13 +76,13 @@ extension VelociPlayer {
     }
     
     internal func prepareNewPlayerItem() {
+        self.currentItemSubscribers = []
         guard let currentItem = self.currentItem else {
             return
         }
         self.mediaURL = (currentItem.asset as? AVURLAsset)?.url
         currentItem.preferredForwardBufferDuration = 10
         
-        self.currentItemSubscribers = []
         currentItem.publisher(for: \.isPlaybackBufferEmpty)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isPlaybackBufferEmpty in


### PR DESCRIPTION
This PR ensures two things:

- Current Item subscribers are cleared when calling `stop()`
- Current Item subscribers are cleared when setting the current item or `mediaURL` to `nil`