### PR TITLE
Remove False Error

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer.swift
@@ -158,13 +158,7 @@ public class VelociPlayer: AVPlayer, ObservableObject {
                await self.seek(to: startTime)
             }
             
-            let isLoaded = await self.preroll(atRate: 1.0)
-            guard isLoaded else {
-                await MainActor.run {
-                    self.currentError = .unableToBuffer
-                }
-                return
-            }
+            await self.preroll(atRate: 1.0)
             
             await MainActor.run {
                 self.isBuffering = true


### PR DESCRIPTION
VelociPlayer could sometimes give a false error while buffering a video, if pre-loading fails but the video is still able to buffer