### PR TITLE
HLS Videos End Early

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Buffering.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Buffering.swift
@@ -24,7 +24,7 @@ extension VelociPlayer {
     internal func updateBufferTime(timeRanges: [NSValue]) {
         if let timeRange = timeRanges.first?.timeRangeValue {
             guard !timeRange.end.seconds.isNaN && !duration.seconds.isNaN && !duration.seconds.isZero else {
-                self.bufferTime = CMTime(seconds: 0, preferredTimescale: 10_000)
+                self.bufferTime = VPTime(seconds: 0, preferredTimescale: 10_000)
                 self.bufferProgress = 0
                 return
             }

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -70,6 +70,15 @@ extension VelociPlayer {
                 self?.onPlayerTimeControlled()
             }
             .store(in: &subscribers)
+        
+        NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime, object: nil)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                if (notification.object as? AVPlayerItem == self?.currentItem) && self?.progress != 1 {
+                    self?.progress = 1
+                }
+            }
+            .store(in: &subscribers)
     }
     
     internal func mediaURLChanged() {

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -18,7 +18,7 @@ extension VelociPlayer {
         }
         guard !time.seconds.isNaN && !duration.seconds.isNaN && !duration.seconds.isZero else {
             self.progress = 0
-            self.time = CMTime(seconds: 0, preferredTimescale: 10_000)
+            self.time = VPTime(seconds: 0, preferredTimescale: 10_000)
             return
         }
         self.progress = time.seconds / duration.seconds
@@ -74,8 +74,10 @@ extension VelociPlayer {
         NotificationCenter.default.publisher(for: .AVPlayerItemDidPlayToEndTime, object: nil)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] notification in
-                if (notification.object as? AVPlayerItem == self?.currentItem) && self?.progress != 1 {
-                    self?.progress = 1
+                guard let self = self else { return }
+                if (notification.object as? AVPlayerItem == self.currentItem) && self.progress != 1 {
+                    self.duration = self.time
+                    self.progress = 1
                 }
             }
             .store(in: &subscribers)

--- a/Sources/VelociPlayer/Source/VelociPlayer.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer.swift
@@ -21,7 +21,7 @@ public class VelociPlayer: AVPlayer, ObservableObject {
     @Published public internal(set) var progress = 0.0
     
     /// The playback time of the current item.
-    @Published public internal(set) var time = VPTime(seconds: 0, preferredTimescale: 1)
+    @Published public internal(set) var time = VPTime(seconds: 0, preferredTimescale: 10_000)
     
     /// Indicates if playback is currently paused.
     @Published public internal(set) var isPaused = true
@@ -30,13 +30,13 @@ public class VelociPlayer: AVPlayer, ObservableObject {
     @Published public internal(set) var isBuffering = false
     
     /// The furthest point of the current item that is currently buffered.
-    @Published public internal(set) var bufferTime = VPTime(seconds: 0, preferredTimescale: 1)
+    @Published public internal(set) var bufferTime = VPTime(seconds: 0, preferredTimescale: 10_000)
     
     /// The furthest point of the current item that is currently buffered as a percentage: Ranges from 0 to 1.
     @Published public internal(set) var bufferProgress = 0.0
     
     /// The total length of the currently playing item.
-    @Published public internal(set) var duration = VPTime(seconds: 0, preferredTimescale: 1)
+    @Published public internal(set) var duration = VPTime(seconds: 0, preferredTimescale: 10_000)
     
     /// The caption that should currently be displayed.
     @Published public internal(set) var currentCaption: Caption?


### PR DESCRIPTION
Added AVPlayerItemDidPlayToEndTime notification back, with some checks to verify it's accurate and we're not sending repeated values.

Update the duration when the video ends "early"