### PR TITLE
Resolve Duration Override

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -76,7 +76,7 @@ extension VelociPlayer {
             .sink { [weak self] notification in
                 guard let self = self else { return }
                 if (notification.object as? AVPlayerItem == self.currentItem) && self.progress != 1 {
-                    self.duration = self.time
+                    self.time = self.duration
                     self.progress = 1
                 }
             }


### PR DESCRIPTION
The last version introduced a bug where if a video fails to load, the duration is set to 0:00 and is not reloaded. This PR addresses this issue