### PR TITLE
[Patch] Player not observed before playing

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
@@ -15,7 +15,7 @@ extension VelociPlayer {
     
     /// Begin playback of the current item
     public override func play() {
-        self.observePlayerOnUserInteraction()
+        self.beginPlayerObservationIfNeeded()
         self.autoPlay = true
         super.play()
     }

--- a/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
@@ -15,10 +15,6 @@ extension VelociPlayer {
     
     /// Begin playback of the current item
     public override func play() {
-        if timeObserver == nil {
-            startObservingPlayer()
-            setAVCategory()
-        }
         self.autoPlay = true
         super.play()
     }

--- a/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Controls.swift
@@ -15,6 +15,7 @@ extension VelociPlayer {
     
     /// Begin playback of the current item
     public override func play() {
+        self.observePlayerOnUserInteraction()
         self.autoPlay = true
         super.play()
     }

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -89,11 +89,6 @@ extension VelociPlayer {
         
         let playerItem = AVPlayerItem(url: mediaURL)
         self.replaceCurrentItem(with: playerItem)
-        
-        if timeObserver == nil {
-            startObservingPlayer()
-            setAVCategory()
-        }
     }
     
     internal func prepareNewPlayerItem() {
@@ -152,6 +147,14 @@ extension VelociPlayer {
         
         Task.detached {
             await self.updateCurrentItemDuration()
+        }
+    }
+    
+    internal func observePlayerOnUserInteraction() {
+        if timeObserver == nil {
+            print("observing the player")
+            startObservingPlayer()
+            setAVCategory()
         }
     }
 }

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -89,6 +89,11 @@ extension VelociPlayer {
         
         let playerItem = AVPlayerItem(url: mediaURL)
         self.replaceCurrentItem(with: playerItem)
+        
+        if timeObserver == nil {
+            startObservingPlayer()
+            setAVCategory()
+        }
     }
     
     internal func prepareNewPlayerItem() {

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -152,7 +152,6 @@ extension VelociPlayer {
     
     internal func observePlayerOnUserInteraction() {
         if timeObserver == nil {
-            print("observing the player")
             startObservingPlayer()
             setAVCategory()
         }

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -150,7 +150,7 @@ extension VelociPlayer {
         }
     }
     
-    internal func observePlayerOnUserInteraction() {
+    internal func beginPlayerObservationIfNeeded() {
         if timeObserver == nil {
             startObservingPlayer()
             setAVCategory()

--- a/Sources/VelociPlayer/Source/VelociPlayer+Seeking.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Seeking.swift
@@ -69,7 +69,7 @@ extension VelociPlayer {
     /// - Returns: A boolean indicating whether the seek operation completed.
     @discardableResult
     override public func seek(to time: VPTime) async -> Bool {
-        self.observePlayerOnUserInteraction()
+        self.beginPlayerObservationIfNeeded()
         let completed = await super.seek(to: time)
         await updateNowPlayingForSeeking()
         return completed

--- a/Sources/VelociPlayer/Source/VelociPlayer+Seeking.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Seeking.swift
@@ -69,6 +69,7 @@ extension VelociPlayer {
     /// - Returns: A boolean indicating whether the seek operation completed.
     @discardableResult
     override public func seek(to time: VPTime) async -> Bool {
+        self.observePlayerOnUserInteraction()
         let completed = await super.seek(to: time)
         await updateNowPlayingForSeeking()
         return completed


### PR DESCRIPTION
### Description
It seems like the player is only observed only after being played. When not autoplayed, users can't initially seek. I was thinking just moving observing the player when the media changes. Let me know if this would be a viable solution, if other changes are required or if you have any other feedback.

### Screenshots/Screen Recording

https://user-images.githubusercontent.com/46248987/216675160-28152fe0-f44b-4d73-92b3-5f1f3f3bce4e.mov

### Type of change

- [ ] Feature (newly added functionality not yet in production)
- [ ] Bug (fixing functionality not yet in production)
- [X] Patch (fixing functionality currently in production)
- [ ] Clean or Refactor (updates to existing code that does not change functionality)

### JIRA-related:

| Ticket | Description |
| [Issue-28](https://github.com/DATechnologies/VelociPlayer/issues/28) | Seeking without ever pressing play |