### PR TITLE
Fix system player controls not being relinquished

### DIFF
--- a/Sources/VelociPlayer/Source/Now Playing/VelociPlayer+NowPlaying.swift
+++ b/Sources/VelociPlayer/Source/Now Playing/VelociPlayer+NowPlaying.swift
@@ -40,6 +40,7 @@ extension VelociPlayer {
     
     internal func removeFromNowPlaying() {
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        disableAllCommands()
     }
     
     internal func setUpMainControl() {
@@ -153,8 +154,8 @@ extension VelociPlayer {
     
     internal func disableAllCommands() {
         for (command, target) in commandTargets {
-          command.isEnabled = false
-          command.removeTarget(target)
+            command.isEnabled = false
+            command.removeTarget(target)
         }
     }
     

--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -154,6 +154,9 @@ extension VelociPlayer {
         if timeObserver == nil {
             startObservingPlayer()
             setAVCategory()
+            if displayInSystemPlayer {
+                setUpNowPlayingControls()
+            }
         }
     }
 }

--- a/Sources/VelociPlayer/Source/VelociPlayer.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer.swift
@@ -67,7 +67,7 @@ public class VelociPlayer: AVPlayer, ObservableObject {
     /// Determines whether the player should integrate with the system to allow playback controls from Control Center and the Lock Screen, among other places.
     public var displayInSystemPlayer = false {
         didSet {
-            if displayInSystemPlayer {
+            if displayInSystemPlayer && timeObserver != nil {
                 setUpNowPlayingControls()
             } else {
                 removeFromNowPlaying()


### PR DESCRIPTION
This PR resolves a bug that would cause VelociPlayer to continue listening to the system controls after disabling now playing support. It also ensures that VelociPlayer no longer takes over the system player until it begins playback.