### PR TITLE
Fix Progress Observation

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -21,7 +21,7 @@ extension VelociPlayer {
             self.time = VPTime(seconds: 0, preferredTimescale: 10_000)
             return
         }
-        self.progress = time.seconds / duration.seconds
+        self.progress = min(time.seconds / duration.seconds, 1)
         self.time = time
     }
     


### PR DESCRIPTION
When using AVPlayer's `actionAtItemEnd = .none`, it is possible for the player's time to continue after the playback has finished. This fixes a bug where VelociPlayer's `progress` property could be set to a value larger than 1, which is not intended. 

**/// The playback progress of the current item: Ranges from 0 to 1.**
`@Published public internal(set) var progress = 0.0`