### PR TITLE
Prevent starting task if captions are nil

### DIFF
--- a/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
+++ b/Sources/VelociPlayer/Source/VelociPlayer+Observation.swift
@@ -13,8 +13,10 @@ import Combine
 extension VelociPlayer {
     // MARK: - Player Observation
     internal func onPlayerTimeChanged(time: VPTime) {
-        Task.detached {
-            await self.updateCaptions(time: time)
+        if allCaptions != nil {
+            Task.detached {
+                await self.updateCaptions(time: time)
+            }
         }
         guard !time.seconds.isNaN && !duration.seconds.isNaN && !duration.seconds.isZero else {
             self.progress = 0


### PR DESCRIPTION
### Media
![image](https://github.com/DATechnologies/VelociPlayer/assets/46248987/3c52b321-d0ba-4847-b476-e136326b9dfa)

### Description
- Prevent the task from being started if not needed (saw it clogging up instruments with it constantly firing).

### Type of change

- [ ] Feature (newly added functionality not yet in production)
- [ ] Bug (fixing functionality not yet in production)
- [ ] Patch (fixing functionality currently in production)
- [X] Clean or Refactor (updates to existing code that does not change functionality)
